### PR TITLE
showing .hp command on freeze not needed.

### DIFF
--- a/MatchBot/MatchStats.cpp
+++ b/MatchBot/MatchStats.cpp
@@ -1308,7 +1308,8 @@ bool CMatchStats::ShowHP(CBasePlayer* Player, bool Command, bool InConsole)
 		{
 			if (g_pGameRules)
 			{
-				if (!Player->IsAlive() || CSGameRules()->m_bRoundTerminating || CSGameRules()->IsFreezePeriod())
+				// Removed || CSGameRules()->IsFreezePeriod(), showing full enemy team hp on freezetime its not needed.
+				if (!Player->IsAlive() || CSGameRules()->m_bRoundTerminating)
 				{
 					if (Player->m_iTeam == TERRORIST || Player->m_iTeam == CT)
 					{


### PR DESCRIPTION
Hi, I was doing some tests, and I saw that .hp command on freezetime was showing enemy full team hp. 

Commands as .sum .dmg .rdmg not need to remove since they store the values on next round. 