### PR TITLE
Restore buytime when pause ends.

### DIFF
--- a/MatchBot/MatchPause.cpp
+++ b/MatchBot/MatchPause.cpp
@@ -77,13 +77,6 @@ void CMatchPause::RoundRestart()
 			// Disable it
 			this->m_Pause = false;
 
-			// If map has buyzone
-			if (CSGameRules()->m_bMapHasBuyZone)
-			{
-				// Restore default buy time
-				g_engfuncs.pfnCVarSetFloat("mp_buytime", this->m_BuyTime);
-			}
-
 			// Pause for 60 seconds
 			this->SetRoundTime(static_cast<int>(gMatchBot.m_PauseTime->value) + 1, true);
 
@@ -147,10 +140,29 @@ void CMatchPause::PauseTimer(int PauseTime)
 			// Remove Pause Task
 			gMatchTask.Remove(TASK_PAUSE_MATCH);
 
+			//restore buytime when pause end
+			gMatchPause.RestoreBuyTimeOnPauseEnd();
+
 			// Restore Freezetime
 			gMatchPause.SetRoundTime((int)CVAR_GET_FLOAT("mp_freezetime"), true);
 		}
 	}
+}
+
+void CMatchPause::RestoreBuyTimeOnPauseEnd()
+{
+
+	// If has CS Game Rules
+	if (g_pGameRules)
+	{
+		//if has buyzone
+		if (CSGameRules()->m_bMapHasBuyZone)
+		{
+			// Restore default buy time
+			g_engfuncs.pfnCVarSetFloat("mp_buytime", this->m_BuyTime);
+		}
+	}
+
 }
 
 void CMatchPause::SetRoundTime(int Time, bool FreezePeriod)

--- a/MatchBot/MatchPause.cpp
+++ b/MatchBot/MatchPause.cpp
@@ -147,7 +147,7 @@ void CMatchPause::PauseTimer(int PauseTime)
 				if (CSGameRules()->m_bMapHasBuyZone)
 				{
 					// Restore default buy time
-					g_engfuncs.pfnCVarSetFloat("mp_buytime", this->m_BuyTime);
+					g_engfuncs.pfnCVarSetFloat("mp_buytime", gMatchPause.m_BuyTime);
 				}
 			}
 

--- a/MatchBot/MatchPause.cpp
+++ b/MatchBot/MatchPause.cpp
@@ -139,9 +139,17 @@ void CMatchPause::PauseTimer(int PauseTime)
 		{
 			// Remove Pause Task
 			gMatchTask.Remove(TASK_PAUSE_MATCH);
-
-			//restore buytime when pause end
-			gMatchPause.RestoreBuyTimeOnPauseEnd();
+			
+			// If has CS Game Rules
+			if (g_pGameRules)
+			{
+				//if has buyzone
+				if (CSGameRules()->m_bMapHasBuyZone)
+				{
+					// Restore default buy time
+					g_engfuncs.pfnCVarSetFloat("mp_buytime", this->m_BuyTime);
+				}
+			}
 
 			// Restore Freezetime
 			gMatchPause.SetRoundTime((int)CVAR_GET_FLOAT("mp_freezetime"), true);
@@ -149,21 +157,6 @@ void CMatchPause::PauseTimer(int PauseTime)
 	}
 }
 
-void CMatchPause::RestoreBuyTimeOnPauseEnd()
-{
-
-	// If has CS Game Rules
-	if (g_pGameRules)
-	{
-		//if has buyzone
-		if (CSGameRules()->m_bMapHasBuyZone)
-		{
-			// Restore default buy time
-			g_engfuncs.pfnCVarSetFloat("mp_buytime", this->m_BuyTime);
-		}
-	}
-
-}
 
 void CMatchPause::SetRoundTime(int Time, bool FreezePeriod)
 {

--- a/MatchBot/MatchPause.h
+++ b/MatchBot/MatchPause.h
@@ -7,8 +7,6 @@ public:
 
 	void RoundRestart();
 
-	void RestoreBuyTimeOnPauseEnd();
-
 	static void PauseTimer(int PauseTime);
 
 	void SetRoundTime(int Time, bool FreezePeriod);

--- a/MatchBot/MatchPause.h
+++ b/MatchBot/MatchPause.h
@@ -7,6 +7,8 @@ public:
 
 	void RoundRestart();
 
+	void RestoreBuyTimeOnPauseEnd();
+
 	static void PauseTimer(int PauseTime);
 
 	void SetRoundTime(int Time, bool FreezePeriod);

--- a/MatchBot/MatchPause.h
+++ b/MatchBot/MatchPause.h
@@ -10,6 +10,7 @@ public:
 	static void PauseTimer(int PauseTime);
 
 	void SetRoundTime(int Time, bool FreezePeriod);
+	
 private:
 	bool	m_Pause   = false;
 	float	m_BuyTime = 0.0f;


### PR DESCRIPTION
I did this modifications because when round starts buytime was changed to 0.25 automatically. 
So I did a fn that send this change when you remove TASK_PAUSE_MATCH.
