### PR TITLE
Fixing texts on readme.md and language.json 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ At the end, server will start a vote map to changelevel to next map automaticall
     <li>ReHLDS</li>
     <li>ReGameDLL_CS</li>
     <li>Metamod</li>
-    <li>Libcurl</li>
 </ul> 
 
 <h3>Features</h3>
@@ -92,9 +91,7 @@ At the end, server will start a vote map to changelevel to next map automaticall
 | mb_restrict_weapons                |000000000000000000000000000000000000000| Restricted Weapons by item index slot position (1 to block item, 0 to allow). <br />`0` Shieldgun. <br /> `1` P228. <br /> `2` Glock. <br /> `3` Scout. <br /> `4` Hegrenade. <br /> `5` Xm1014. <br /> `6` C4. <br /> `7` Mac10. <br /> `8` Aug. <br /> `9` Smokegrenade. <br /> `10` Elite. <br /> `11` Fiveseven. <br /> `12` Ump45. <br /> `13` Sg550. <br /> `14` Galil. <br /> `15` Famas. <br /> `16` Usp. <br /> `17` Glock18. <br /> `18` Awp. <br /> `19` Mp5n. <br /> `20` M249. <br /> `21` M3. <br /> `22` M4a1. <br /> `23` Tmp. <br /> `24` G3sg1. <br /> `25` Flashbang. <br /> `26` Deagle. <br /> `27` Sg552. <br /> `28` Ak47. <br /> `29` Knife. <br /> `30` P90. <br /> `31` Nvg. <br /> `32` Defusekit. <br /> `33` Kevlar. <br /> `34` Assault. <br /> `35` Longjump. <br /> `36` Sodacan. <br /> `37` Healthkit. <br /> `38` Antidote. <br /> `39` Battery. |
 | mb_extra_smoke_count               | 2        | Extra Smokegranade explosion fix .<br /> `0` Disabled. <br /> `n` Number of extra smoke puffs. |
 | mb_pause_time                      | 60.0     | Amount of seconds to pause match. <br /> `0` Disabled. <br /> `n` Or number of seconds to pause the match. |
-
-| mb_retry_mode                      | 0        | Anti reconnect mode. <br /> `0` Disabled. <br /> `1` Enable when player explicity drop from server. <br / > `2` Enable for any disconnect reason. |
-
+| mb_retry_mode                      | 0        | Anti reconnect mode. <br /> `0` Disabled. <br /> `1` Enable when player explicity drop from server. <br /> `2` Enable for any disconnect reason. |
 | mb_retry_time                      | 30.0     | Anti reconnect time  <br /> Time in seconds to prevent the player reconnect to server |
 | mb_help_file                       | cstrike/addons/matchbot/users_help.html     | Users Help File or Website url (Without HTTPS). <br /> If is website url, works only with HTTP (Not HTTPS).|
 | mb_help_file_admin                 | cstrike/addons/matchbot/admin_help.html      | Admin Help File or Website url (Without HTTPS). <br /> If is website url, works only with HTTP (Not HTTPS).|

--- a/cstrike/addons/matchbot/language.json
+++ b/cstrike/addons/matchbot/language.json
@@ -1184,13 +1184,13 @@
     "You have muted ^3%s...": {
         "en": "You have muted ^3%s...",
         "bp": "Você mutou ^3%s...",
-        "es": "Has muteado a^3%s...",
+        "es": "Has muteado a ^3%s...",
         "ru": "Вы отключили звук ^3%s..."
     },
     "You have unmuted ^3%s...": {
         "en": "You have unmuted ^3%s...",
         "bp": "Você está ouvindo ^3%s...",
-        "es": "Has desmuteado a^3%s...",
+        "es": "Has desmuteado a ^3%s...",
         "ru": "Вы разблокировали ^3%s..."
     }
 }

--- a/cstrike/addons/matchbot/language.json
+++ b/cstrike/addons/matchbot/language.json
@@ -1079,7 +1079,6 @@
         "es": "Ya votaste para cancelar la partida.",
         "ru": "Вы уже проголосовали за отмену матча."
     },
-
     "Wait %d seconds before reconnect.": {
         "en": "Wait %d seconds before reconnect.",
         "bp": "Aguarde %d segundos antes de reconectar-se.",
@@ -1087,10 +1086,10 @@
         "ru": "Подождите %d секунд перед повторным подключением."
     },
     "Player List": {
-	"en": "Player List",
-	"bp": "Jogadores",
-	"es": "Listado Jugadores",
-	"ru": "Список игроков"
+	    "en": "Player List",
+	    "bp": "Jogadores",
+	    "es": "Listado Jugadores",
+	    "ru": "Список игроков"
     },
     "Online": {
         "en": "Online",

--- a/cstrike/addons/matchbot/language.json
+++ b/cstrike/addons/matchbot/language.json
@@ -168,16 +168,16 @@
         "ru": "Выберите время для бана: ^w%s^y"
     },
     "banid %d #%d kick": {
-	"en": "banid %d #%d kick",
-	"bp": "banid %d #%d kick",
-	"es": "banid %d #%d kick",
-	"ru": "banid %d #%d kick"
+	    "en": "banid %d #%d kick",
+	    "bp": "banid %d #%d kick",
+	    "es": "banid %d #%d kick",
+	    "ru": "banid %d #%d kick"
     },
     "banid %d %s kick": {
-	"en": "banid %d %s kick",
-	"bp": "banid %d %s kick",
-	"es": "banid %d %s kick",
-	"ru": "banid %d %s kick"
+	    "en": "banid %d %s kick",
+	    "bp": "banid %d %s kick",
+	    "es": "banid %d %s kick",
+	    "ru": "banid %d %s kick"
     },
     "Change Team": {
         "en": "Change Team",

--- a/cstrike/addons/matchbot/language.json
+++ b/cstrike/addons/matchbot/language.json
@@ -1079,54 +1079,7 @@
         "es": "Ya votaste para cancelar la partida.",
         "ru": "Вы уже проголосовали за отмену матча."
     },
-    "Select player to report:": {
-        "en": "Select player to report:",
-        "bp": "Selecione um jogador para reportar:",
-        "es": "Seleccionar jugador para reportar:",
-        "ru": "Выберите игрока для жалобы:"
-    },
-    "Select player to report with reason: ^3%s.": {
-        "en": "Select player to report with reason: ^3%s.",
-        "bp": "Selecione um jogador para reportar com o seguinte motivo: ^3%s.",
-        "es": "Seleccionar jugador a denunciar con motivo: ^3%s.",
-        "ru": "Выберите игрока для жалобы с причиной: ^3%s."
-    },
-    "Server can't detect players connected.": {
-        "en": "Server can't detect players connected.",
-        "bp": "O Servidor não encontrou jogadores conectados.",
-        "es": "El servidor no puede detectar jugadores conectados.",
-        "ru": "Сервер не может обнаружить подключенных игроков."
-    },
-    "The reason must be at least %d characters long.": {
-        "en": "The reason must be at least %d characters long.",
-        "bp": "O motivo precisa ter pelo menos %d caracteres.",
-        "es": "El motivo debe tener al menos %d caracteres.",
-        "ru": "Причина должна быть длиной не менее %d символов."
-    },
-    "Usage: .report ^3<Description of report>^1": {
-        "en": "Usage: .report ^3<Description of report>^1",
-        "bp": "Uso: .report ^3<Descrição do relatório>^1",
-        "es": "Uso: .report ^3<Descripción del informe>^1",
-        "ru": "Использование: .report ^3<Описание жалобы>^1"
-    },
-    "Report about ^3%s^1 sent at %s.": {
-        "en": "Report about ^3%s^1 sent at %s.",
-        "bp": "Relato contra o jogador ^3%s^1 enviado em %s.",
-        "es": "Informe sobre ^3%s^1 enviado a %s.",
-        "ru": "Жалоба на игрока ^3%s^1 отправлена %s."
-    },
-    "Administrators will review the report and take action if needed.": {
-        "en": "Administrators will review the report and take action if needed.",
-        "bp": "Os administradores vão revisar o relato e tomar providências se necessário.",
-        "es": "Los administradores revisarán el informe y tomarán medidas si es necesario.",
-        "ru": "Администраторы рассмотрят жалобу и примут меры при необходимости."
-    },
-    "Failed to authenticate, contact us: %s": {
-        "en": "Failed to authenticate, contact us: %s",
-        "bp": "Falha ao autenticar, entre em contato: %s",
-        "es": "No se ha podido autenticar, contáctenos: %s",
-        "ru": "Не удалось аутентифицироваться, свяжитесь с нами: %s"
-    },
+
     "Wait %d seconds before reconnect.": {
         "en": "Wait %d seconds before reconnect.",
         "bp": "Aguarde %d segundos antes de reconectar-se.",
@@ -1136,7 +1089,7 @@
     "Player List": {
 	"en": "Player List",
 	"bp": "Jogadores",
-	"es": "Jugadore",
+	"es": "Listado Jugadores",
 	"ru": "Список игроков"
     },
     "Online": {
@@ -1173,7 +1126,7 @@
         "en": "Steam",
         "bp": "Steam",
         "es": "Steam",
-        "ru": "Пар"
+        "ru": "Стим"
     },
     "Address": {
         "en": "Address",
@@ -1184,7 +1137,7 @@
     "Flags": {
         "en": "Flags",
         "bp": "Acesso",
-        "es": "IP",
+        "es": "Acceso",
         "ru": "Доступ"
     },
     "Team": {
@@ -1196,20 +1149,14 @@
     "User Index": {
         "en": "User Index",
         "bp": "User Index",
-        "es": "User Index",
+        "es": "Indice Usuario",
         "ru": "Индекс пользователя"
     },
     "Status": {
         "en": "Status",
         "bp": "Status",
         "es": "Estado",
-        "ru": "Положение дел"
-    },
-    "Status": {
-        "en": "Status",
-        "bp": "Status",
-        "es": "Estado",
-        "ru": "Положение дел"
+        "ru": "Статус"
     },
     "^3%s^1 is not in connected.": {
         "en": "^3%s^1 is not in connected.",
@@ -1226,7 +1173,7 @@
     "%s ^r^RMuted": {
         "en": "%s ^r^RMuted",
         "bp": "%s ^r^RMudo",
-        "es": "%s ^r^RApagado",
+        "es": "%s ^r^RMuteado",
         "ru": "%s ^r^RПриглушен"
     },
     "%s ^r^RListening": {
@@ -1238,13 +1185,13 @@
     "You have muted ^3%s...": {
         "en": "You have muted ^3%s...",
         "bp": "Você mutou ^3%s...",
-        "es": "Tú has silenciado ^3%s...",
+        "es": "Has muteado a^3%s...",
         "ru": "Вы отключили звук ^3%s..."
     },
     "You have unmuted ^3%s...": {
         "en": "You have unmuted ^3%s...",
         "bp": "Você está ouvindo ^3%s...",
-        "es": "Has des-silenciado ^3%s...",
+        "es": "Has desmuteado a^3%s...",
         "ru": "Вы разблокировали ^3%s..."
     }
 }


### PR DESCRIPTION
Removing libcurl from readme.md since its not used anymore.

Fixing matchbot cvar table since its breaks if get spacing.

Removing .report texts on language.json since its not more working on matchbot.

Fixing some translations and text on language.json